### PR TITLE
Moves javaws path to arch dependent build files

### DIFF
--- a/consts_darwin.go
+++ b/consts_darwin.go
@@ -1,0 +1,5 @@
+package main
+
+const(
+  DefaultJavaPath = "/usr/bin/javaws"
+)

--- a/consts_linux.go
+++ b/consts_linux.go
@@ -1,0 +1,5 @@
+package main
+
+const(
+  DefaultJavaPath = "/usr/bin/javaws"
+)

--- a/consts_windows_amd64.go
+++ b/consts_windows_amd64.go
@@ -1,0 +1,5 @@
+package main
+
+const (
+  DefaultJavaPath = "C:\\Program Files (x86)\\Java\\jre7\\bin\\javaws.exe"
+)

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 var _host = pflag.StringP("host", "h", "some.hostname.com", "The DRAC host (or IP)")
 var _username = pflag.StringP("username", "u", "", "The DRAC username")
 var _password = pflag.BoolP("password", "p", false, "Prompt for password (optional, will use 'calvin' if not present)")
-var javaws = pflag.StringP("javaws", "j", "/usr/bin/javaws", "The path to javaws binary")
+var javaws = pflag.StringP("javaws", "j", DefaultJavaPath, "The path to javaws binary")
 
 
 func promptPassword() string {


### PR DESCRIPTION
Changes the javaws path to a const, which is defined differently for the different GOOS/GOARCH

This allows for me to not have to pass the -j param when on windows as mentioned in #8

The paths are applicable to my env (& its probably not the best way to do it, but hey I'm playing around in Go)
