### PR TITLE
Changes to HEAD in jar version check

### DIFF
--- a/drac.go
+++ b/drac.go
@@ -57,7 +57,7 @@ func (d *DRAC) GetVersion() int {
 	}
 
 	// Check for iDRAC7 specific libs
-	if response, err := client.Get("https://" + d.Host + "/software/avctKVMIOMac64.jar"); err == nil {
+	if response, err := client.Head("https://" + d.Host + "/software/avctKVMIOMac64.jar"); err == nil {
 		defer response.Body.Close()
 		if response.StatusCode == 200 {
 			return 7
@@ -65,7 +65,7 @@ func (d *DRAC) GetVersion() int {
 	}
 
 	// Check for iDRAC6 specific libs
-	if response, err := client.Get("https://" + d.Host + "/software/jpcsc.jar"); err == nil {
+	if response, err := client.Head("https://" + d.Host + "/software/jpcsc.jar"); err == nil {
 		defer response.Body.Close()
 		if response.StatusCode == 200 {
 			return 6


### PR DESCRIPTION
Since we are just checking for 200 OK return code (aka not a 404), maybe it is not worth GETing the entire jar file. Just a small thought for fun
