### PR TITLE
Add [defaults] config parsing for username/pw.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Configuration file
 You can create a configuration file
 ```bash
 $ cat ~/.drackvmrc
+# Override the hardcoded defaults for username and password.
+# Useful if your environment has consistent usernames and
+# passwords for the KVMs.
+[defaults]
+username = foo
+password = bar
+
 [192.168.0.42]
 username = foo
 password = bar


### PR DESCRIPTION
In some environments, there is a consistent username and password
that is not the vendor default.  Instead of hardcoding the site
specific credentials, allow for reading a defaults section out of
the config file so it overrides the vendor-specific default.
